### PR TITLE
Update entry on change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN go mod download
 # Copy the go source
 COPY main.go main.go
 COPY config.go config.go
-COPY api/ api/
 COPY controllers/ controllers/
 
 # Build

--- a/config.go
+++ b/config.go
@@ -36,8 +36,8 @@ func LoadConfig(path string) (*Config, error) {
 }
 
 func ParseConfig(hclConfig string) (*Config, error) {
-	c := new(Config)
-	if err := hcl.Decode(c, hclConfig); err != nil {
+	c := Config{}
+	if err := hcl.Decode(&c, hclConfig); err != nil {
 		return nil, errs.New("unable to decode configuration: %v", err)
 	}
 
@@ -60,5 +60,5 @@ func ParseConfig(hclConfig string) (*Config, error) {
 		c.ControllerName = defaultControllerName
 	}
 
-	return c, nil
+	return &c, nil
 }

--- a/controllers/base_controller.go
+++ b/controllers/base_controller.go
@@ -209,13 +209,17 @@ func (r *BaseReconciler) deleteAllEntries(ctx context.Context, reqLogger logr.Lo
 }
 
 func (r *BaseReconciler) deleteAllEntriesExcept(ctx context.Context, reqLogger logr.Logger, entries []*common.RegistrationEntry, exceptEntryId string) error {
+	var errs []error
 	for _, entry := range entries {
 		if entry.EntryId != exceptEntryId {
 			err := r.ensureDeleted(ctx, reqLogger, entry.EntryId)
 			if err != nil {
-				return err
+				errs = append(errs, err)
 			}
 		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("unable to delete all entries: %v", errs)
 	}
 	return nil
 }

--- a/controllers/base_controller.go
+++ b/controllers/base_controller.go
@@ -134,6 +134,12 @@ func (r *BaseReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 		if requiresUpdate {
 			reqLogger.V(1).Info("Updating existing spire entry to match desired state", "entry", matchedEntries[0].EntryId)
+			// It's important that if multiple instances are running they all pick the same entry here, otherwise
+			// we could have two instances of the registrar delete each others changes. This can only happen if both are
+			// also working off an up to date cache (otherwise the lagging one will pick up the other change later and correct
+			// the mistake.) If that happens then as long as the list of entries is always in the same order, we can guarantee they
+			// wont end up deleting all the entries and not noticing.
+			// TODO: Check that spire-server provides a stable sort order, or sort it ourselves!
 			myEntryId = matchedEntries[0].EntryId
 
 			myEntry.EntryId = myEntryId

--- a/controllers/base_controller.go
+++ b/controllers/base_controller.go
@@ -143,7 +143,7 @@ func (r *BaseReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			// It's important that if multiple instances are running they all pick the same entry here, otherwise
 			// we could have two instances of the registrar delete each others changes. This can only happen if both are
 			// also working off an up to date cache (otherwise the lagging one will pick up the other change later and correct
-			// the mistake.) If that happens then as long as they'd both pick the same entry to keep off the list, we can
+			// the mistake.) If that happens then as long as they'd both pick to keep the same entry from the list, we can
 			// guarantee they wont end up deleting all the entries and not noticing: so we'll pick the entry with the
 			// "lowest" Entry ID.
 			myEntryId := matchedEntries[0].EntryId


### PR DESCRIPTION
This allows the updating of an existing server entry if the spiffe ID changes, preventing a period where the workload might be without an SVID.
It also avoids an additional CreateIfNotExists call if the entry already happens to exist.
This change requires us to protect against a situation where two copies of the registrar might delete all the entries for a pod.
We also allow the syncer to detect mismatches between the content of entries on the server and expected state. This may lead to queuing additional reconciliations that'd have sorted themselves out otherwise, but I think that's OK in order to be able to clean up a few more weird cases (like people changing entries on the server.)